### PR TITLE
김채연/[feat] 분석 내역 구현

### DIFF
--- a/back/rushWash/src/main/java/com/rushWash/domain/washings/api/WasingRestController.java
+++ b/back/rushWash/src/main/java/com/rushWash/domain/washings/api/WasingRestController.java
@@ -1,0 +1,39 @@
+package com.rushWash.domain.washings.api;
+
+import com.rushWash.common.response.ApiResponse;
+import com.rushWash.domain.users.api.dto.request.UserDuplicateCheckRequest;
+import com.rushWash.domain.washings.api.dto.request.WashingDetailRequest;
+import com.rushWash.domain.washings.api.dto.response.WashingDetailResponse;
+import com.rushWash.domain.washings.api.dto.response.WashingListResponse;
+import com.rushWash.domain.washings.service.WashingService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/washings")
+public class WasingRestController {
+
+    private final WashingService washingService;
+    //private final Tokense
+
+    @GetMapping
+    public ApiResponse<WashingListResponse> getWashingList(
+            /*@RequestHeader("Authorization") String authHeader*/) {
+        int userId = 1; // userID
+        WashingListResponse response = washingService.getWashingListByUserId(userId);
+
+        return ApiResponse.ok(response);
+    }
+
+    @GetMapping("/{washingHistoryId}")
+    public ApiResponse<WashingDetailResponse> getWashingDetail(
+            /*@RequestHeader("Authorization") String authHeader*/
+            @PathVariable int washingHistoryId) {
+        int userId = 1; // userID
+        WashingDetailResponse response = washingService.getWashingDetailByUserIdAndWashingHistoryId(userId, washingHistoryId);
+        return ApiResponse.ok(response);
+    }
+}

--- a/back/rushWash/src/main/java/com/rushWash/domain/washings/api/dto/request/WashingDetailRequest.java
+++ b/back/rushWash/src/main/java/com/rushWash/domain/washings/api/dto/request/WashingDetailRequest.java
@@ -1,0 +1,6 @@
+package com.rushWash.domain.washings.api.dto.request;
+
+public record WashingDetailRequest(
+        int washingHistoryId
+) {
+}

--- a/back/rushWash/src/main/java/com/rushWash/domain/washings/api/dto/response/WashingDetailResponse.java
+++ b/back/rushWash/src/main/java/com/rushWash/domain/washings/api/dto/response/WashingDetailResponse.java
@@ -1,0 +1,21 @@
+package com.rushWash.domain.washings.api.dto.response;
+
+import com.rushWash.domain.washings.domain.AnalysisType;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record WashingDetailResponse(
+
+        int id,
+        String stainImageUrl,
+        String labelImageUrl,
+        AnalysisType analysisType,
+        String stainCategory,
+        String analysis,
+        boolean estimation,
+        LocalDateTime createdAt
+
+
+) {
+}

--- a/back/rushWash/src/main/java/com/rushWash/domain/washings/api/dto/response/WashingList.java
+++ b/back/rushWash/src/main/java/com/rushWash/domain/washings/api/dto/response/WashingList.java
@@ -1,0 +1,14 @@
+package com.rushWash.domain.washings.api.dto.response;
+
+import com.rushWash.domain.washings.domain.AnalysisType;
+
+import java.time.LocalDateTime;
+
+public record WashingList(
+        int washingHistoryId,
+        AnalysisType analysisType,
+        String analysis,
+        boolean estimation,
+        LocalDateTime createdAt
+) {
+}

--- a/back/rushWash/src/main/java/com/rushWash/domain/washings/api/dto/response/WashingListResponse.java
+++ b/back/rushWash/src/main/java/com/rushWash/domain/washings/api/dto/response/WashingListResponse.java
@@ -1,0 +1,11 @@
+package com.rushWash.domain.washings.api.dto.response;
+
+import com.rushWash.domain.washings.domain.AnalysisType;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record WashingListResponse(
+        List<WashingList> WashingList
+) {
+}

--- a/back/rushWash/src/main/java/com/rushWash/domain/washings/domain/AnalysisType.java
+++ b/back/rushWash/src/main/java/com/rushWash/domain/washings/domain/AnalysisType.java
@@ -1,0 +1,8 @@
+package com.rushWash.domain.washings.domain;
+
+public enum AnalysisType {
+    STAIN,
+    LABEL_AND_STAIN,
+    LABEL
+}
+

--- a/back/rushWash/src/main/java/com/rushWash/domain/washings/domain/WashingHistory.java
+++ b/back/rushWash/src/main/java/com/rushWash/domain/washings/domain/WashingHistory.java
@@ -1,0 +1,39 @@
+package com.rushWash.domain.washings.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.UpdateTimestamp;
+import java.time.LocalDateTime;
+
+@Entity
+@ToString
+@Table(name = "washing_history")
+@Getter
+@Builder(toBuilder = true)
+@NoArgsConstructor
+@AllArgsConstructor
+public class WashingHistory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int id;
+    @Column(name = "user_id")
+    private int userId;
+    @Enumerated(EnumType.STRING)
+    @Column(name = "analysis_type")
+    private AnalysisType analysisType;
+
+    @Column(name = "stain_image_url")
+    private String stainImageUrl;
+
+    @Column(name = "label_image_url")
+    private String labelImageUrl;
+
+    private boolean estimation;
+    @Column(name = "created_at", updatable = false)
+    @UpdateTimestamp
+    private LocalDateTime createdAt;
+    @Column(name = "updated_at")
+    @UpdateTimestamp
+    private LocalDateTime updatedAt;
+}

--- a/back/rushWash/src/main/java/com/rushWash/domain/washings/domain/WashingResult.java
+++ b/back/rushWash/src/main/java/com/rushWash/domain/washings/domain/WashingResult.java
@@ -1,0 +1,37 @@
+package com.rushWash.domain.washings.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+
+@Entity
+@ToString
+@Table(name="washing_result")
+@Getter
+@Builder(toBuilder = true)
+@NoArgsConstructor
+@AllArgsConstructor
+public class WashingResult {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int id;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "washing_history_id", nullable = false)
+    private WashingHistory washingHistory;
+    @Column(name = "stain_category")
+    private String stainCategory;
+
+    private String analysis;
+
+    @Column(name = "created_at", updatable = false)
+    @UpdateTimestamp
+    private LocalDateTime createdAt;
+    @Column(name = "updated_at")
+    @UpdateTimestamp
+    private LocalDateTime updatedAt;
+
+}

--- a/back/rushWash/src/main/java/com/rushWash/domain/washings/domain/repository/WashingRepository.java
+++ b/back/rushWash/src/main/java/com/rushWash/domain/washings/domain/repository/WashingRepository.java
@@ -1,0 +1,46 @@
+package com.rushWash.domain.washings.domain.repository;
+
+import com.rushWash.domain.washings.api.dto.response.WashingDetailResponse;
+import com.rushWash.domain.washings.api.dto.response.WashingList;
+import com.rushWash.domain.washings.domain.WashingHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface WashingRepository extends JpaRepository<WashingHistory, Integer> {
+    @Query("""
+    SELECT new com.rushWash.domain.washings.api.dto.response.WashingList(
+        wh.id,
+        wh.analysisType,
+        wr.analysis,
+        wh.estimation,
+        wh.createdAt
+    )
+    FROM WashingHistory wh
+    JOIN WashingResult wr ON wr.washingHistory.id = wh.id
+    WHERE wh.userId = :userId
+    ORDER BY wh.createdAt DESC
+""")
+    List<WashingList> findItemsByUserId(@Param("userId") int userId);
+
+
+    @Query("""
+    SELECT new com.rushWash.domain.washings.api.dto.response.WashingDetailResponse(
+        wh.id,
+        wh.stainImageUrl,
+        wh.labelImageUrl,
+        wh.analysisType,
+        wr.stainCategory,
+        wr.analysis,
+        wh.estimation,
+        wh.createdAt
+    )
+    FROM WashingHistory wh
+    JOIN WashingResult wr ON wr.washingHistory.id = wh.id
+    WHERE wh.userId = :userId AND wh.id = :washingHistoryId
+    ORDER BY wh.createdAt DESC
+""")
+    WashingDetailResponse findDetailByUserIdAndWashingHistoryId(@Param("userId") int userId, @Param(("washingHistoryId")) int washingHistoryId);
+}

--- a/back/rushWash/src/main/java/com/rushWash/domain/washings/service/WashingService.java
+++ b/back/rushWash/src/main/java/com/rushWash/domain/washings/service/WashingService.java
@@ -1,0 +1,30 @@
+package com.rushWash.domain.washings.service;
+
+import com.rushWash.domain.washings.api.dto.response.WashingDetailResponse;
+import com.rushWash.domain.washings.api.dto.response.WashingList;
+import com.rushWash.domain.washings.api.dto.response.WashingListResponse;
+import com.rushWash.domain.washings.domain.repository.WashingRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class WashingService {
+
+    private final WashingRepository washingRepository;
+
+    public WashingListResponse getWashingListByUserId(int userId) {
+        List<WashingList> list = washingRepository.findItemsByUserId(userId);
+        return new WashingListResponse(list);
+
+    }
+
+    public WashingDetailResponse getWashingDetailByUserIdAndWashingHistoryId(int userId, int washingHistoryId) {
+
+        return washingRepository.findDetailByUserIdAndWashingHistoryId(userId, washingHistoryId);
+
+    }
+
+}


### PR DESCRIPTION
## 상세 설명
- userId를 이용하여 분석 목록(analysisType, analysis, estimation, createdAt)을 조회했습니다
- userId와 washing_history테이블의 id를 이용하여 상세 내용(stainImageUrl, labelImageUrl, analysisType, stainCategory, analysis, estimation, createdAt)을 조회했습니다

## 어려웠던 점
Spring Data JPA에서 JPQL을 처음 사용해보아서 사용법이 조금 낯설었다 하지만 DTO로 원하는 필드만 가져오기에 성능도 향상되고 유지보수가 쉬워 앞으로 자주 사용할 것 같다