### PR TITLE
전수현 / [feat] 관리자 기능 - 사용자 관리 구현

### DIFF
--- a/back/.idea/modules/rushWash.iml
+++ b/back/.idea/modules/rushWash.iml
@@ -7,6 +7,11 @@
       <excludeFolder url="file://$MODULE_DIR$/../../rushWash/build" />
       <excludeFolder url="file://$MODULE_DIR$/../../rushWash/out" />
     </content>
+    <content url="file://$MODULE_DIR$/../../rushWash">
+      <excludeFolder url="file://$MODULE_DIR$/../../rushWash/.gradle" />
+      <excludeFolder url="file://$MODULE_DIR$/../../rushWash/build" />
+      <excludeFolder url="file://$MODULE_DIR$/../../rushWash/out" />
+    </content>
     <orderEntry type="jdk" jdkName="17" jdkType="JavaSDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>

--- a/back/.idea/modules/rushWash.main.iml
+++ b/back/.idea/modules/rushWash.main.iml
@@ -8,6 +8,11 @@
       <sourceFolder url="file://$MODULE_DIR$/../../rushWash/src/main/java" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/../../rushWash/src/main/resources" type="java-resource" />
     </content>
+    <content url="file://$MODULE_DIR$/../../rushWash/src/main">
+      <sourceFolder url="file://$MODULE_DIR$/../../rushWash/src/main/generated" isTestSource="false" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/../../rushWash/src/main/java" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/../../rushWash/src/main/resources" type="java-resource" />
+    </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" scope="PROVIDED" name="Gradle: org.springframework.boot:spring-boot-configuration-processor:3.4.5" level="project" />

--- a/back/.idea/modules/rushWash.test.iml
+++ b/back/.idea/modules/rushWash.test.iml
@@ -6,6 +6,9 @@
     <content url="file://$MODULE_DIR$/../../rushWash/src/test">
       <sourceFolder url="file://$MODULE_DIR$/../../rushWash/src/test/java" isTestSource="true" />
     </content>
+    <content url="file://$MODULE_DIR$/../../rushWash/src/test">
+      <sourceFolder url="file://$MODULE_DIR$/../../rushWash/src/test/java" isTestSource="true" />
+    </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="module" module-name="rushWash.main" />

--- a/back/rushWash/src/main/java/com/rushWash/domain/admin/users/api/AdminUsersRestController.java
+++ b/back/rushWash/src/main/java/com/rushWash/domain/admin/users/api/AdminUsersRestController.java
@@ -1,0 +1,43 @@
+package com.rushWash.domain.admin.users.api;
+
+import com.rushWash.common.response.ApiResponse;
+import com.rushWash.domain.admin.users.api.dto.request.AdminUserDeleteRequest;
+import com.rushWash.domain.admin.users.api.dto.request.AdminUserUpdateRequest;
+import com.rushWash.domain.admin.users.service.AdminUsersService;
+import com.rushWash.domain.users.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admin/users")
+public class AdminUsersRestController {
+
+    private final AdminUsersService adminUsersService;
+
+    @GetMapping
+    public ApiResponse<List<User>> getUserList(){
+
+        return ApiResponse.ok(adminUsersService.getUserLit());
+    }
+
+    @PatchMapping
+    public ApiResponse<String> updateUser(
+            @RequestBody AdminUserUpdateRequest request){
+
+        adminUsersService.updateUser(request.userId(), request.name(), request.email(), request.phoneNumber());
+
+        return ApiResponse.ok("사용자 업데이트 완료");
+    }
+
+    @DeleteMapping
+    public ApiResponse<String> deleteUser(
+            @RequestBody AdminUserDeleteRequest request){
+
+        adminUsersService.deleteUser(request.userId());
+
+        return ApiResponse.ok("사용자 삭제 완료");
+    }
+}

--- a/back/rushWash/src/main/java/com/rushWash/domain/admin/users/api/dto/request/AdminUserDeleteRequest.java
+++ b/back/rushWash/src/main/java/com/rushWash/domain/admin/users/api/dto/request/AdminUserDeleteRequest.java
@@ -1,0 +1,6 @@
+package com.rushWash.domain.admin.users.api.dto.request;
+
+public record AdminUserDeleteRequest(
+        int userId
+) {
+}

--- a/back/rushWash/src/main/java/com/rushWash/domain/admin/users/api/dto/request/AdminUserUpdateRequest.java
+++ b/back/rushWash/src/main/java/com/rushWash/domain/admin/users/api/dto/request/AdminUserUpdateRequest.java
@@ -1,0 +1,9 @@
+package com.rushWash.domain.admin.users.api.dto.request;
+
+public record AdminUserUpdateRequest(
+        int userId,
+        String name,
+        String email,
+        String phoneNumber
+) {
+}

--- a/back/rushWash/src/main/java/com/rushWash/domain/admin/users/service/AdminUsersService.java
+++ b/back/rushWash/src/main/java/com/rushWash/domain/admin/users/service/AdminUsersService.java
@@ -1,0 +1,29 @@
+package com.rushWash.domain.admin.users.service;
+
+import com.rushWash.domain.admin.users.api.dto.request.AdminUserUpdateRequest;
+import com.rushWash.domain.users.domain.User;
+import com.rushWash.domain.users.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AdminUsersService {
+
+    private final UserService userService;
+
+    public List<User> getUserLit(){
+        return userService.getUserList();
+    }
+
+    public void updateUser(int userId, String name, String email, String phoneNumber){
+        userService.updateUser(userId, name, email, phoneNumber);
+    }
+
+    public void deleteUser(int userId){
+        userService.deleteUser(userId);
+    }
+}

--- a/back/rushWash/src/main/java/com/rushWash/domain/users/api/UserRestController.java
+++ b/back/rushWash/src/main/java/com/rushWash/domain/users/api/UserRestController.java
@@ -1,6 +1,8 @@
 package com.rushWash.domain.users.api;
 
 import com.rushWash.common.response.ApiResponse;
+import com.rushWash.common.response.CustomException;
+import com.rushWash.common.response.ErrorCode;
 import com.rushWash.domain.users.api.dto.request.*;
 import com.rushWash.domain.users.api.dto.response.*;
 import com.rushWash.domain.users.service.UserService;
@@ -31,7 +33,11 @@ public class UserRestController {
 
     @PostMapping("/sign-out")
     public ApiResponse<String> userSignOut(
-            @RequestHeader("Authorization") String authHeader) {
+            @RequestHeader(name = "Authorization", required = false) String authHeader) {
+
+        if (authHeader == null || authHeader.isEmpty()){
+            throw new CustomException(ErrorCode.INVALID_TOKEN);
+        }
 
         String accessToken = authHeader.substring(7);
         userService.signOut(accessToken);

--- a/back/rushWash/src/main/java/com/rushWash/domain/users/domain/User.java
+++ b/back/rushWash/src/main/java/com/rushWash/domain/users/domain/User.java
@@ -28,4 +28,10 @@ public class User {
     @Column(name = "updated_at")
     @UpdateTimestamp
     private LocalDateTime updatedAt;
+
+    public void updateInfo(String name, String email, String phoneNumber) {
+        this.name = name;
+        this.email = email;
+        this.phoneNumber = phoneNumber;
+    }
 }

--- a/back/rushWash/src/main/java/com/rushWash/domain/users/domain/repository/UserRepository.java
+++ b/back/rushWash/src/main/java/com/rushWash/domain/users/domain/repository/UserRepository.java
@@ -4,6 +4,8 @@ import com.rushWash.domain.users.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 public interface UserRepository extends JpaRepository<User, Integer> {
     boolean existsByPhoneNumber(String phoneNumber);
 
@@ -14,5 +16,5 @@ public interface UserRepository extends JpaRepository<User, Integer> {
 
     User findByNameAndEmail(String name, String email);
 
-    User findById(int id);
+    Optional<User> findById(int id);
 }

--- a/back/rushWash/src/main/java/com/rushWash/domain/users/service/UserService.java
+++ b/back/rushWash/src/main/java/com/rushWash/domain/users/service/UserService.java
@@ -16,6 +16,9 @@ import com.rushWash.global.security.jwt.JwtUtil;
 import com.rushWash.global.security.jwt.repository.TokenStore;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -152,10 +155,8 @@ public class UserService {
     }
 
     public UserPasswordResponse resetPassword(UserPasswordRequest request) {
-        User user = userRepository.findById(request.userId());
-        if (user == null) {
-            throw new CustomException(ErrorCode.USER_NOT_FOUND);
-        }
+        User user = userRepository.findById(request.userId())
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         String hashedPassword = EncryptUtils.sha256(request.password());
         user = user.toBuilder() // 기존 내용은 그대로
@@ -166,4 +167,21 @@ public class UserService {
         return new UserPasswordResponse(true, "비밀번호 변경 성공", user.getId());
     }
 
+    public List<User> getUserList(){
+        return userRepository.findAll();
+    }
+
+    @Transactional
+    public void updateUser(int userId, String name, String email, String phoneNumber){
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        user.updateInfo(name, email, phoneNumber);
+    }
+
+    public void deleteUser(int userId){
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        userRepository.deleteById(userId);
+    }
 }

--- a/back/rushWash/src/main/java/com/rushWash/domain/washings/api/WashingRestController.java
+++ b/back/rushWash/src/main/java/com/rushWash/domain/washings/api/WashingRestController.java
@@ -1,6 +1,8 @@
 package com.rushWash.domain.washings.api;
 
 import com.rushWash.common.response.ApiResponse;
+import com.rushWash.common.response.CustomException;
+import com.rushWash.common.response.ErrorCode;
 import com.rushWash.domain.users.service.TokenService;
 import com.rushWash.domain.washings.api.dto.request.WashingEstimationRequest;
 import com.rushWash.domain.washings.api.dto.response.WashingDetailResponse;
@@ -19,7 +21,12 @@ public class WashingRestController {
 
     @GetMapping
     public ApiResponse<WashingListResponse> getWashingList(
-            @RequestHeader("Authorization") String authHeader) {
+            @RequestHeader(name = "Authorization", required = false) String authHeader) {
+
+        if (authHeader == null || authHeader.isEmpty()){
+            throw new CustomException(ErrorCode.INVALID_TOKEN);
+        }
+
         int userId = tokenService.extractUserIdFromHeader(authHeader);
         WashingListResponse response = washingService.getWashingListByUserId(userId);
 
@@ -28,8 +35,13 @@ public class WashingRestController {
 
     @GetMapping("/{washingHistoryId}")
     public ApiResponse<WashingDetailResponse> getWashingDetail(
-            @RequestHeader("Authorization") String authHeader,
+            @RequestHeader(name = "Authorization", required = false) String authHeader,
             @PathVariable int washingHistoryId) {
+
+        if (authHeader == null || authHeader.isEmpty()){
+            throw new CustomException(ErrorCode.INVALID_TOKEN);
+        }
+
         int userId = tokenService.extractUserIdFromHeader(authHeader);
         WashingDetailResponse response = washingService.getWashingDetailByUserIdAndWashingHistoryId(userId, washingHistoryId);
         return ApiResponse.ok(response);
@@ -39,7 +51,12 @@ public class WashingRestController {
     public ApiResponse<String> washingEstimation(
             @PathVariable int washingHistoryId,
             @RequestBody WashingEstimationRequest request,
-            @RequestHeader("Authorization") String authHeader) {
+            @RequestHeader(name = "Authorization", required = false) String authHeader) {
+
+        if (authHeader == null || authHeader.isEmpty()){
+            throw new CustomException(ErrorCode.INVALID_TOKEN);
+        }
+
         int userId = tokenService.extractUserIdFromHeader(authHeader);
         washingService.updateWashingHistory(userId, washingHistoryId, request);
 


### PR DESCRIPTION
## 무슨 이유로 코드를?
- 관리자 사용자 관리 구현
  - user DB 조회
  - user DB 수정
  - user DB 삭제
- 헤더 null, empty error처리 

## 어려운 점
- 원래 수정할 때 user를 불러와서 toBuilder를 사용해서 덮어씌우고 save 했는데 비효율적인 코드라는 걸 알게 돼서 다른 방식으로 수정을 함
- user.updateInfo(...) 메소드를 하나 만들어서 user 내용을 업데이트 해주고 @Transactional 어노테이션을 붙이면 JPA의 특성 때문에 자동으로 변경된 필드로만 update 쿼리가 실행된다. => '더티체킹' 이라고 부름
참고링크: https://velog.io/@chiyongs/JPA-JPA%EC%9D%98-UPDATE%EB%B0%A9%EC%8B%9D%EA%B3%BC-Dirty-Checking

## 관련 스크린샷
- 조회
![스크린샷 2025-05-07 222739](https://github.com/user-attachments/assets/8817b389-4a0b-4b56-8085-ffd1f203d179)
- 수정
![스크린샷 2025-05-07 231400](https://github.com/user-attachments/assets/c8feb9b7-6b2c-4e95-9b2e-6cae44ef43e3)
- 삭제 (수정과 비슷.. 까먹고 못 찍음)

## 완료사항
- user DB 조회, 수정, 삭제
- 에러처리

## 추가사항
closed #19 