### PR TITLE
전수현 / [feat] 관리자 기능 - 섬유유연제 관리 구현

### DIFF
--- a/back/.idea/modules/rushWash.iml
+++ b/back/.idea/modules/rushWash.iml
@@ -7,11 +7,6 @@
       <excludeFolder url="file://$MODULE_DIR$/../../rushWash/build" />
       <excludeFolder url="file://$MODULE_DIR$/../../rushWash/out" />
     </content>
-    <content url="file://$MODULE_DIR$/../../rushWash">
-      <excludeFolder url="file://$MODULE_DIR$/../../rushWash/.gradle" />
-      <excludeFolder url="file://$MODULE_DIR$/../../rushWash/build" />
-      <excludeFolder url="file://$MODULE_DIR$/../../rushWash/out" />
-    </content>
     <orderEntry type="jdk" jdkName="17" jdkType="JavaSDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>

--- a/back/.idea/modules/rushWash.main.iml
+++ b/back/.idea/modules/rushWash.main.iml
@@ -8,11 +8,6 @@
       <sourceFolder url="file://$MODULE_DIR$/../../rushWash/src/main/java" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/../../rushWash/src/main/resources" type="java-resource" />
     </content>
-    <content url="file://$MODULE_DIR$/../../rushWash/src/main">
-      <sourceFolder url="file://$MODULE_DIR$/../../rushWash/src/main/generated" isTestSource="false" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/../../rushWash/src/main/java" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/../../rushWash/src/main/resources" type="java-resource" />
-    </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" scope="PROVIDED" name="Gradle: org.springframework.boot:spring-boot-configuration-processor:3.4.5" level="project" />

--- a/back/.idea/modules/rushWash.test.iml
+++ b/back/.idea/modules/rushWash.test.iml
@@ -6,9 +6,6 @@
     <content url="file://$MODULE_DIR$/../../rushWash/src/test">
       <sourceFolder url="file://$MODULE_DIR$/../../rushWash/src/test/java" isTestSource="true" />
     </content>
-    <content url="file://$MODULE_DIR$/../../rushWash/src/test">
-      <sourceFolder url="file://$MODULE_DIR$/../../rushWash/src/test/java" isTestSource="true" />
-    </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="module" module-name="rushWash.main" />

--- a/back/rushWash/src/main/java/com/rushWash/domain/admin/fabricSofteneres/api/AdminFabricSoftenerRestController.java
+++ b/back/rushWash/src/main/java/com/rushWash/domain/admin/fabricSofteneres/api/AdminFabricSoftenerRestController.java
@@ -2,6 +2,7 @@ package com.rushWash.domain.admin.fabricSofteneres.api;
 
 import com.rushWash.common.response.ApiResponse;
 import com.rushWash.domain.admin.fabricSofteneres.api.dto.request.AdminFabricSoftenerDeleteRequest;
+import com.rushWash.domain.admin.fabricSofteneres.api.dto.request.AdminFabricSoftenerRequest;
 import com.rushWash.domain.admin.fabricSofteneres.api.dto.request.AdminFabricSoftenerUpdateRequest;
 import com.rushWash.domain.admin.fabricSofteneres.service.AdminFabricSoftenerService;
 import com.rushWash.domain.fabricSofteners.domain.FabricSoftener;
@@ -21,6 +22,14 @@ public class AdminFabricSoftenerRestController {
     public ApiResponse<List<FabricSoftener>> getFabricSoftenerList() {
 
         return ApiResponse.ok(adminFabricSoftenerService.getFabricSoftenerList());
+    }
+
+    @PostMapping
+    public ApiResponse<String> addFabricSoftener(
+            @RequestBody AdminFabricSoftenerRequest request){
+        adminFabricSoftenerService.addFabricSoftener(request.scentCategory(), request.brand(), request.productName());
+
+        return ApiResponse.ok("섬유유연제 생성 완료");
     }
 
     @PatchMapping

--- a/back/rushWash/src/main/java/com/rushWash/domain/admin/fabricSofteneres/api/AdminFabricSoftenerRestController.java
+++ b/back/rushWash/src/main/java/com/rushWash/domain/admin/fabricSofteneres/api/AdminFabricSoftenerRestController.java
@@ -1,6 +1,7 @@
 package com.rushWash.domain.admin.fabricSofteneres.api;
 
 import com.rushWash.common.response.ApiResponse;
+import com.rushWash.domain.admin.fabricSofteneres.api.dto.request.AdminFabricSoftenerDeleteRequest;
 import com.rushWash.domain.admin.fabricSofteneres.api.dto.request.AdminFabricSoftenerUpdateRequest;
 import com.rushWash.domain.admin.fabricSofteneres.service.AdminFabricSoftenerService;
 import com.rushWash.domain.fabricSofteners.domain.FabricSoftener;
@@ -29,5 +30,13 @@ public class AdminFabricSoftenerRestController {
                 request.brand(), request.productName());
 
         return ApiResponse.ok("섬유유연제 업데이트 완료");
+    }
+
+    @DeleteMapping
+    public ApiResponse<String> deleteFabricSoftenerByFabricSoftenerId(
+            @RequestBody AdminFabricSoftenerDeleteRequest request){
+        adminFabricSoftenerService.deleteFabricSoftenerByFabricSoftenerId(request.fabricSoftenerId());
+
+        return ApiResponse.ok("섬유유연제 삭제 완료");
     }
 }

--- a/back/rushWash/src/main/java/com/rushWash/domain/admin/fabricSofteneres/api/AdminFabricSoftenerRestController.java
+++ b/back/rushWash/src/main/java/com/rushWash/domain/admin/fabricSofteneres/api/AdminFabricSoftenerRestController.java
@@ -4,12 +4,8 @@ import com.rushWash.common.response.ApiResponse;
 import com.rushWash.domain.admin.fabricSofteneres.api.dto.request.AdminFabricSoftenerUpdateRequest;
 import com.rushWash.domain.admin.fabricSofteneres.service.AdminFabricSoftenerService;
 import com.rushWash.domain.fabricSofteners.domain.FabricSoftener;
-import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -26,4 +22,12 @@ public class AdminFabricSoftenerRestController {
         return ApiResponse.ok(adminFabricSoftenerService.getFabricSoftenerList());
     }
 
+    @PatchMapping
+    public ApiResponse<String> updateFabricSoftenerByFabricSoftenerId(
+            @RequestBody AdminFabricSoftenerUpdateRequest request){
+        adminFabricSoftenerService.updateFabricSoftenerByFabricSoftenerId(request.fabricSoftenerId(), request.scentCategory(),
+                request.brand(), request.productName());
+
+        return ApiResponse.ok("섬유유연제 업데이트 완료");
+    }
 }

--- a/back/rushWash/src/main/java/com/rushWash/domain/admin/fabricSofteneres/api/AdminFabricSoftenerRestController.java
+++ b/back/rushWash/src/main/java/com/rushWash/domain/admin/fabricSofteneres/api/AdminFabricSoftenerRestController.java
@@ -1,0 +1,29 @@
+package com.rushWash.domain.admin.fabricSofteneres.api;
+
+import com.rushWash.common.response.ApiResponse;
+import com.rushWash.domain.admin.fabricSofteneres.api.dto.request.AdminFabricSoftenerUpdateRequest;
+import com.rushWash.domain.admin.fabricSofteneres.service.AdminFabricSoftenerService;
+import com.rushWash.domain.fabricSofteners.domain.FabricSoftener;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admin/fabric-softeners")
+public class AdminFabricSoftenerRestController {
+
+    private final AdminFabricSoftenerService adminFabricSoftenerService;
+
+    @GetMapping
+    public ApiResponse<List<FabricSoftener>> getFabricSoftenerList() {
+
+        return ApiResponse.ok(adminFabricSoftenerService.getFabricSoftenerList());
+    }
+
+}

--- a/back/rushWash/src/main/java/com/rushWash/domain/admin/fabricSofteneres/api/dto/request/AdminFabricSoftenerDeleteRequest.java
+++ b/back/rushWash/src/main/java/com/rushWash/domain/admin/fabricSofteneres/api/dto/request/AdminFabricSoftenerDeleteRequest.java
@@ -1,0 +1,6 @@
+package com.rushWash.domain.admin.fabricSofteneres.api.dto.request;
+
+public record AdminFabricSoftenerDeleteRequest(
+        int fabricSoftenerId
+) {
+}

--- a/back/rushWash/src/main/java/com/rushWash/domain/admin/fabricSofteneres/api/dto/request/AdminFabricSoftenerRequest.java
+++ b/back/rushWash/src/main/java/com/rushWash/domain/admin/fabricSofteneres/api/dto/request/AdminFabricSoftenerRequest.java
@@ -1,0 +1,8 @@
+package com.rushWash.domain.admin.fabricSofteneres.api.dto.request;
+
+public record AdminFabricSoftenerRequest(
+        String scentCategory,
+        String brand,
+        String productName
+) {
+}

--- a/back/rushWash/src/main/java/com/rushWash/domain/admin/fabricSofteneres/api/dto/request/AdminFabricSoftenerUpdateRequest.java
+++ b/back/rushWash/src/main/java/com/rushWash/domain/admin/fabricSofteneres/api/dto/request/AdminFabricSoftenerUpdateRequest.java
@@ -1,0 +1,6 @@
+package com.rushWash.domain.admin.fabricSofteneres.api.dto.request;
+
+public record AdminFabricSoftenerUpdateRequest(
+        int fabricSoftenerId
+) {
+}

--- a/back/rushWash/src/main/java/com/rushWash/domain/admin/fabricSofteneres/api/dto/request/AdminFabricSoftenerUpdateRequest.java
+++ b/back/rushWash/src/main/java/com/rushWash/domain/admin/fabricSofteneres/api/dto/request/AdminFabricSoftenerUpdateRequest.java
@@ -1,6 +1,9 @@
 package com.rushWash.domain.admin.fabricSofteneres.api.dto.request;
 
 public record AdminFabricSoftenerUpdateRequest(
-        int fabricSoftenerId
+        int fabricSoftenerId,
+        String scentCategory,
+        String brand,
+        String productName
 ) {
 }

--- a/back/rushWash/src/main/java/com/rushWash/domain/admin/fabricSofteneres/service/AdminFabricSoftenerService.java
+++ b/back/rushWash/src/main/java/com/rushWash/domain/admin/fabricSofteneres/service/AdminFabricSoftenerService.java
@@ -1,8 +1,8 @@
-package com.rushWash.domain.fabricSofteners.service;
+package com.rushWash.domain.admin.fabricSofteneres.service;
 
-import com.rushWash.domain.fabricSofteners.api.dto.response.FabricSoftenerResponse;
 import com.rushWash.domain.fabricSofteners.domain.FabricSoftener;
 import com.rushWash.domain.fabricSofteners.domain.repository.FabricSoftenerRepository;
+import com.rushWash.domain.fabricSofteners.service.FabricSoftenerService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -10,16 +10,12 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
-public class FabricSoftenerService {
+public class AdminFabricSoftenerService {
 
+    private final FabricSoftenerService fabricSoftenerService;
     private final FabricSoftenerRepository fabricSoftenerRepository;
 
-    public List<FabricSoftenerResponse> getFabricSoftenerList(String fabricScent){
-        return fabricSoftenerRepository.findFabricSoftenerListByScentCategory(fabricScent);
-    }
-
     public List<FabricSoftener> getFabricSoftenerList(){
-        return fabricSoftenerRepository.findAll();
+        return fabricSoftenerService.getFabricSoftenerList();
     }
-
 }

--- a/back/rushWash/src/main/java/com/rushWash/domain/admin/fabricSofteneres/service/AdminFabricSoftenerService.java
+++ b/back/rushWash/src/main/java/com/rushWash/domain/admin/fabricSofteneres/service/AdminFabricSoftenerService.java
@@ -1,10 +1,13 @@
 package com.rushWash.domain.admin.fabricSofteneres.service;
 
+import com.rushWash.common.response.CustomException;
+import com.rushWash.common.response.ErrorCode;
 import com.rushWash.domain.fabricSofteners.domain.FabricSoftener;
 import com.rushWash.domain.fabricSofteners.domain.repository.FabricSoftenerRepository;
 import com.rushWash.domain.fabricSofteners.service.FabricSoftenerService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -17,5 +20,12 @@ public class AdminFabricSoftenerService {
 
     public List<FabricSoftener> getFabricSoftenerList(){
         return fabricSoftenerService.getFabricSoftenerList();
+    }
+
+    @Transactional
+    public void updateFabricSoftenerByFabricSoftenerId(int fabricSoftenerId, String scentCategory, String brand, String productName){
+        FabricSoftener fabricSoftener = fabricSoftenerRepository.findById(fabricSoftenerId)
+                .orElseThrow(() -> new CustomException(ErrorCode.FABRIC_CATEGORY_NOT_FOUND));
+        fabricSoftener.updateInfo(scentCategory, brand, productName);
     }
 }

--- a/back/rushWash/src/main/java/com/rushWash/domain/admin/fabricSofteneres/service/AdminFabricSoftenerService.java
+++ b/back/rushWash/src/main/java/com/rushWash/domain/admin/fabricSofteneres/service/AdminFabricSoftenerService.java
@@ -22,6 +22,16 @@ public class AdminFabricSoftenerService {
         return fabricSoftenerService.getFabricSoftenerList();
     }
 
+    public void addFabricSoftener(String scentCategory, String brand, String productName){
+        fabricSoftenerRepository.save(
+                FabricSoftener.builder()
+                        .scentCategory(scentCategory)
+                        .brand(brand)
+                        .productName(productName)
+                        .build()
+        );
+    }
+
     @Transactional
     public void updateFabricSoftenerByFabricSoftenerId(int fabricSoftenerId, String scentCategory, String brand, String productName){
         FabricSoftener fabricSoftener = fabricSoftenerRepository.findById(fabricSoftenerId)

--- a/back/rushWash/src/main/java/com/rushWash/domain/admin/fabricSofteneres/service/AdminFabricSoftenerService.java
+++ b/back/rushWash/src/main/java/com/rushWash/domain/admin/fabricSofteneres/service/AdminFabricSoftenerService.java
@@ -28,4 +28,11 @@ public class AdminFabricSoftenerService {
                 .orElseThrow(() -> new CustomException(ErrorCode.FABRIC_CATEGORY_NOT_FOUND));
         fabricSoftener.updateInfo(scentCategory, brand, productName);
     }
+
+    public void deleteFabricSoftenerByFabricSoftenerId(int fabricSoftenerId){
+        fabricSoftenerRepository.findById(fabricSoftenerId)
+                .orElseThrow(() -> new CustomException(ErrorCode.FABRIC_CATEGORY_NOT_FOUND));
+
+        fabricSoftenerRepository.deleteById(fabricSoftenerId);
+    }
 }

--- a/back/rushWash/src/main/java/com/rushWash/domain/admin/users/service/AdminUsersService.java
+++ b/back/rushWash/src/main/java/com/rushWash/domain/admin/users/service/AdminUsersService.java
@@ -29,7 +29,7 @@ public class AdminUsersService {
     }
 
     public void deleteUser(int userId){
-        User user = userRepository.findById(userId)
+        userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         userRepository.deleteById(userId);

--- a/back/rushWash/src/main/java/com/rushWash/domain/fabricSofteners/domain/FabricSoftener.java
+++ b/back/rushWash/src/main/java/com/rushWash/domain/fabricSofteners/domain/FabricSoftener.java
@@ -28,4 +28,10 @@ public class FabricSoftener {
     @Column(name = "updated_at")
     @UpdateTimestamp
     private LocalDateTime updatedAt;
+
+    public void updateInfo(String scentCategory, String brand, String productName) {
+        this.scentCategory = scentCategory;
+        this.brand = brand;
+        this.productName = productName;
+    }
 }

--- a/back/rushWash/src/main/java/com/rushWash/domain/fabricSofteners/domain/repository/FabricSoftenerRepository.java
+++ b/back/rushWash/src/main/java/com/rushWash/domain/fabricSofteners/domain/repository/FabricSoftenerRepository.java
@@ -13,4 +13,5 @@ public interface FabricSoftenerRepository extends JpaRepository<FabricSoftener,I
     @Query("SELECT new com.rushWash.domain.fabricSofteners.api.dto.response.FabricSoftenerResponse(f.brand, f.productName) " +
             "FROM FabricSoftener f WHERE f.scentCategory = :fabricScent")
     List<FabricSoftenerResponse> findFabricSoftenerListByScentCategory(@Param("fabricScent") String fabricScent);
+    List<FabricSoftener> findAllByOrderByScentCategory();
 }

--- a/back/rushWash/src/main/java/com/rushWash/domain/fabricSofteners/service/FabricSoftenerService.java
+++ b/back/rushWash/src/main/java/com/rushWash/domain/fabricSofteners/service/FabricSoftenerService.java
@@ -19,7 +19,7 @@ public class FabricSoftenerService {
     }
 
     public List<FabricSoftener> getFabricSoftenerList(){
-        return fabricSoftenerRepository.findAll();
+        return fabricSoftenerRepository.findAllByOrderByScentCategory();
     }
 
 }


### PR DESCRIPTION
## 무슨 이유로 코드를?
- 관리자 섬유유연제관리 구현
- 섬유유연제 DB 조회 
  - 조회시 scentCategroy별로 정렬 
- 섬유유연제 DB 생성
- 섬유유연제 DB 수정
- 섬유유연제 DB 삭제
  - 삭제시 id가 없으면 에러처리

## 어려운 점
<br>

## 관련 스크린샷
- 조회(정렬 - scentCategory로)
![스크린샷 2025-05-09 225446](https://github.com/user-attachments/assets/ae32ac7e-a09c-457e-811b-e597b6f1741c)
- 생성
![스크린샷 2025-05-09 233806](https://github.com/user-attachments/assets/dfd5b28d-176b-41b5-bb4c-ed7fbc771378)
- 수정
![스크린샷 2025-05-09 232253](https://github.com/user-attachments/assets/5b7f7ac9-febe-4ad6-8991-5eb67814ce39)
- 삭제
![스크린샷 2025-05-09 232953](https://github.com/user-attachments/assets/f381b6d9-9ff0-4228-8d1c-70b1e2f7b718)

## 완료사항
- 섬유유연제 DB CRUD

## 추가사항
closed #23 
